### PR TITLE
Delete loops_in_ruby

### DIFF
--- a/loops_in_ruby
+++ b/loops_in_ruby
@@ -1,9 +1,0 @@
-Loops in Ruby are used to execute the same block of code a specified number of times. This chapter details all the loop statements supported by Ruby.
-
-$i = 0
-$num = 5
-
-while $i < $num  do
-   puts("Inside the loop i = #$i" )
-   $i +=1
-end


### PR DESCRIPTION
This was copy and pasted from [another website](https://www.tutorialspoint.com/ruby/ruby_loops.htm), not formatted correctly, and is a duplicate.
